### PR TITLE
fix: use .cid property before falling back to .multihash

### DIFF
--- a/src/resolver.js
+++ b/src/resolver.js
@@ -86,7 +86,7 @@ const cid = promisify((ipfs, path, callback) => {
               try {
                 // assume a Buffer with a valid CID
                 // (cid is allowed instead of multihash since https://github.com/ipld/js-ipld-dag-pb/pull/80)
-                cidOfNextFile = new CID(link.multihash)
+                cidOfNextFile = new CID(link.cid)
               } catch (err) {
                 // fallback to multihash
                 cidOfNextFile = new CID(mh.toB58String(link.multihash))


### PR DESCRIPTION
DAGLinks have a `.cid` property, use that instead of `.multihash`.

From the comment above the line it looks like this was the original intention but for whatever reason it was still using `.multihash`.