### PR TITLE
[WIP] refactor: default to CID v1 and encode with base32

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/ipfs/js-ipfs-http-response#readme",
   "dependencies": {
     "async": "^2.6.1",
-    "cids": "~0.5.7",
+    "cids": "github:multiformats/js-cid#refactor/cidv1base32-default",
     "debug": "^4.1.1",
     "file-type": "^8.0.0",
     "filesize": "^3.6.1",


### PR DESCRIPTION
BREAKING CHANGE: Any v1 CIDs created by this module are base32 encoded when stringified by default.

Depends on:

* [ ] https://github.com/multiformats/js-cid/pull/73