### PR TITLE
chore: use travis

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = {
+  bundlesize: { maxSize: '140kB' },
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: node_js
+cache: npm
+
+stages:
+  - check
+  - test
+  - cov
+
+node_js:
+  - '10'
+
+os:
+  - linux
+  - osx
+
+script: npx nyc -s npm run test:node -- --bail
+after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov
+
+jobs:
+  include:
+    - stage: check
+      script:
+        - npx aegir build --bundlesize
+        - npx aegir commitlint --travis
+        - npx aegir dep-check
+        - npm run lint
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ jobs:
     - stage: check
       script:
         - npx aegir build --bundlesize
-        - npx aegir commitlint --travis
         - npx aegir dep-check
         - npm run lint
 

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,2 +1,0 @@
-// Warning: This file is automatically synced from https://github.com/ipfs/ci-sync so if you want to change it, please change it there and ask someone to sync all repositories.
-javascript()


### PR DESCRIPTION
Move from jenkins to travis.

Windows CI has problems that need to be addressed. This way, for not blocking other PRs I will open an issue to tackle it later [ipfs/js-ipfs-http-response#21](https://github.com/ipfs/js-ipfs-http-response/issues/21)