### PR TITLE
chore: update cids dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/ipfs/js-ipfs-http-response#readme",
   "dependencies": {
     "async": "^2.6.1",
-    "cids": "~0.5.7",
+    "cids": "~0.7.0",
     "debug": "^4.1.1",
     "file-type": "^8.0.0",
     "filesize": "^3.6.1",


### PR DESCRIPTION
BREAKING CHANGE: v1 CIDs created by this module now default to base32 encoding when stringified

refs: https://github.com/ipfs/js-ipfs/issues/1995