### PR TITLE
chore: update ipfs dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "aegir": "^18.0.3",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
-    "ipfs": "0.35.0",
+    "ipfs": "0.36.0",
     "ipfsd-ctl": "~0.42.2"
   },
   "contributors": [


### PR DESCRIPTION
This PR updates the `js-ipfs` devDependency.

The previous PR [ipfs/js-ipfs-http-response#25](https://github.com/ipfs/js-ipfs-http-response/pull/25) broke the CI, as a result of the circular dependency with `js-ipfs`. 

Needs:

- [x] final release of `js-ipfs@0.36`