### PR TITLE
fix: webpack build

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -2,4 +2,12 @@
 
 module.exports = {
   bundlesize: { maxSize: '140kB' },
+  webpack: {
+    node: {
+      // needed by the mime-types module
+      path: true,
+      // needed by readable-web-to-node-stream module used by file-type
+      stream: true
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "test": "aegir test -t node",
     "test:node": "aegir test -t node"
   },
+  "browser": {
+    "file-type": "file-type/browser"
+  },
   "pre-push": [
     "lint",
     "test"


### PR DESCRIPTION
With the updated in #55 the browser build for this module got broken.

With the `file-type` update, we were getting an error from the lack of the `fs` module as described in https://github.com/sindresorhus/file-type/issues/304 The solution was to replace the `file-type` by its browser version in the browser.

Other than that, some installed modules need the node `stream` and `path`, which were added to aegir's webpack config