### PR TITLE
fix: add node dev deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ jobs:
       script:
         - npx aegir dep-check
         - npm run lint
+        - npm run build
 
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "src/index.js",
   "scripts": {
     "lint": "aegir lint",
+    "build": "aegir build",
     "release": "aegir release --target node",
     "release-minor": "aegir release --type minor --target node",
     "test": "aegir test -t node",
@@ -14,10 +15,6 @@
   "browser": {
     "file-type": "file-type/browser"
   },
-  "pre-push": [
-    "lint",
-    "test"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ipfs/js-ipfs-http-response.git"
@@ -52,7 +49,9 @@
     "ipfs": "^0.54.2",
     "ipfsd-ctl": "^7.0.0",
     "it-all": "^1.0.1",
-    "uint8arrays": "^2.0.5"
+    "path": "^0.12.7",
+    "uint8arrays": "^2.0.5",
+    "util": "^0.12.3"
   },
   "contributors": [
     "Vasco Santos <vasco.santos@moxy.studio>",


### PR DESCRIPTION
With the new aegir update, followed by merging #79 the build fails due to:

```
 > node_modules/mime-types/index.js:16:22: error: Could not resolve "path" (set platform to "node" when building for node)
    16 │ var extname = require('path').extname
       ╵                       ~~~~~~

 > node_modules/web-encoding/src/lib.cjs:4:61: error: Could not resolve "util" (set platform to "node" when building for node)
    4 │   typeof TextEncoder !== "undefined" ? TextEncoder : require("util").TextEncoder
```

This PR adds them as dev deps and adds the build to CI